### PR TITLE
hotfix/removeurl

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -92,6 +92,7 @@ addToQueueBtn.addEventListener('click', async () => {
 
   if (queue.some(item => item.url === url)) {
     alert('This URL is already in the queue. Skipping...');
+    urlInput.value = '';
     return;
   }
 


### PR DESCRIPTION
Remove url from input box when duplication is detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When adding a URL that's already in the queue, the URL input field now clears automatically. This prevents stale text from lingering, makes it clear that no item was added, and reduces accidental repeated submissions. Duplicate detection behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->